### PR TITLE
Revert fargate; switch to large ec2 instance

### DIFF
--- a/groups/data-reconciliation/main.tf
+++ b/groups/data-reconciliation/main.tf
@@ -120,9 +120,6 @@ resource "aws_security_group" "data-reconciliation-security-group" {
 resource "aws_ecs_task_definition" "data-reconciliation-task-definition" {
   family = local.ecs_service_name
   execution_role_arn = module.ecs-cluster.ecs_task_execution_role_arn
-  cpu = var.task_cpu
-  memory = var.task_memory
-  requires_compatibilities = ["FARGATE"]
   container_definitions = templatefile(local.task_config_file, local.ecs_task_config)
 }
 
@@ -131,5 +128,4 @@ resource "aws_ecs_service" "data-reconciliation-ecs-service" {
   cluster = module.ecs-cluster.ecs_cluster_id
   task_definition = aws_ecs_task_definition.data-reconciliation-task-definition.arn
   desired_count = 1
-  launch_type = "FARGATE"
 }

--- a/groups/data-reconciliation/profiles/development-eu-west-2/tbirds1/vars
+++ b/groups/data-reconciliation/profiles/development-eu-west-2/tbirds1/vars
@@ -13,6 +13,3 @@ company_collection_mongo_primary_crontab = "0 0/30 6-17 * * MON-FRI"
 company_collection_mongo_alpha_crontab = "0 0/30 6-17 * * MON-FRI"
 
 results_initial_capacity = 5000000
-
-task_cpu = 512
-task_memory = 4096

--- a/groups/data-reconciliation/task-definition.tmpl
+++ b/groups/data-reconciliation/task-definition.tmpl
@@ -22,6 +22,9 @@
     ],
     "name": "${service_name}",
     "image": "${docker_registry}/${service_name}:${release_version}",
+    "cpu": 1,
+    "memory": 4096,
+    "mountPoints": [],
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {

--- a/groups/data-reconciliation/variables.tf
+++ b/groups/data-reconciliation/variables.tf
@@ -177,13 +177,3 @@ variable "results_initial_capacity" {
   description = "The initial size of the collection of results."
   type = number
 }
-
-variable "task_cpu" {
-  description = "The number of CPU units that will be allocated to the data reconciliation ECS task."
-  type = number
-}
-
-variable "task_memory" {
-  description = "The amount of memory (in MiB) that will be allocated to the data reconciliation ECS task."
-  type = number
-}

--- a/groups/data-reconciliation/variables.tf
+++ b/groups/data-reconciliation/variables.tf
@@ -29,7 +29,7 @@ variable "ec2_key_pair_name" {
 variable "ec2_instance_type" {
   description = "The instance type for ec2 instances in the clusters."
   type = string
-  default = "t3.medium"
+  default = "t3.large"
 }
 
 variable "ec2_image_id" {


### PR DESCRIPTION
* Further investigation required into how to setup Fargate as an ECS
capacity provider.