### PR TITLE
Change EC2 instance type to z1d.large

### DIFF
--- a/groups/data-reconciliation/task-definition.tmpl
+++ b/groups/data-reconciliation/task-definition.tmpl
@@ -22,6 +22,9 @@
     ],
     "name": "${service_name}",
     "image": "${docker_registry}/${service_name}:${release_version}",
+    "cpu": 1,
+    "memory": 4096,
+    "mountPoints": [],
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {

--- a/groups/data-reconciliation/variables.tf
+++ b/groups/data-reconciliation/variables.tf
@@ -29,7 +29,7 @@ variable "ec2_key_pair_name" {
 variable "ec2_instance_type" {
   description = "The instance type for ec2 instances in the clusters."
   type = string
-  default = "t3.large"
+  default = "z1d.large"
 }
 
 variable "ec2_image_id" {


### PR DESCRIPTION
* Change ECS container instance type to z1d.large - currently investigating a memory issue when deploying the data reconciliation app.