### PR TITLE
BI-7645 Add S3 bucket for output and Kafka properties

### DIFF
--- a/groups/data-reconciliation/main.tf
+++ b/groups/data-reconciliation/main.tf
@@ -56,6 +56,11 @@ module "secrets" {
   secrets = data.vault_generic_secret.secrets.data
 }
 
+resource "aws_s3_bucket" "data-reconciliation-bucket" {
+  bucket = local.name_prefix
+  acl = "private"
+}
+
 locals {
   ecs_task_config = merge({
     aws_region = var.aws_region
@@ -79,6 +84,10 @@ locals {
     elasticsearch_alpha_slice_size = var.elasticsearch_alpha_slice_size
     elasticsearch_alpha_slice_field = var.elasticsearch_alpha_slice_field
     results_initial_capacity = var.results_initial_capacity
+    results_bucket = local.name_prefix
+    email_application_id = var.email_application_id
+    email_message_id = var.email_message_id
+    email_message_type = var.email_message_type
     docker_registry = var.docker_registry
     release_version = var.release_version
   }, module.secrets.secrets_arn_map)

--- a/groups/data-reconciliation/task-definition.tmpl
+++ b/groups/data-reconciliation/task-definition.tmpl
@@ -18,7 +18,11 @@
       { "name": "ELASTICSEARCH_ALPHA_SEGMENTS", "value": "${elasticsearch_alpha_segments}" },
       { "name": "ELASTICSEARCH_ALPHA_SLICE_SIZE", "value": "${elasticsearch_alpha_slice_size}" },
       { "name": "ELASTICSEARCH_ALPHA_SLICE_FIELD", "value": "${elasticsearch_alpha_slice_field}" },
-      { "name": "RESULTS_INITIAL_CAPACITY", "value": "${results_initial_capacity}" }
+      { "name": "RESULTS_INITIAL_CAPACITY", "value": "${results_initial_capacity}" },
+      { "name": "RESULTS_BUCKET", "value": "${results_bucket}" },
+      { "name": "EMAIL_APPLICATION_ID", "value": "${email_application_id}" },
+      { "name": "EMAIL_MESSAGE_ID", "value": "${email_message_id}" },
+      { "name": "EMAIL_MESSAGE_TYPE", "value": "${email_message_type}" }
     ],
     "name": "${service_name}",
     "image": "${docker_registry}/${service_name}:${release_version}",
@@ -46,7 +50,11 @@
       { "name": "ELASTICSEARCH_ALPHA_HOST", "valueFrom": "${data-reconciliation-secret-elasticsearch-alpha-host}" },
       { "name": "ELASTICSEARCH_ALPHA_PORT", "valueFrom": "${data-reconciliation-secret-elasticsearch-alpha-port}" },
       { "name": "ELASTICSEARCH_ALPHA_PROTOCOL", "valueFrom": "${data-reconciliation-secret-elasticsearch-alpha-protocol}" },
-      { "name": "ELASTICSEARCH_ALPHA_INDEX", "valueFrom": "${data-reconciliation-secret-elasticsearch-alpha-index}" }
+      { "name": "ELASTICSEARCH_ALPHA_INDEX", "valueFrom": "${data-reconciliation-secret-elasticsearch-alpha-index}" },
+      { "name": "EMAIL_RECIPIENT_LIST", "valueFrom": "${data-reconciliation-secret-email-recipient-list}" },
+      { "name": "EMAIL_SENDER", "valueFrom": "${data-reconciliation-secret-email-sender}" },
+      { "name": "SCHEMA_REGISTRY_URL", "valueFrom": "${data-reconciliation-schema-registry-url}" },
+      { "name": "KAFKA_BROKER_ADDR", "valueFrom": "${data-reconciliation-secret-kafka-broker-addr}" }
     ]
   }
 ]

--- a/groups/data-reconciliation/variables.tf
+++ b/groups/data-reconciliation/variables.tf
@@ -177,3 +177,21 @@ variable "results_initial_capacity" {
   description = "The initial size of the collection of results."
   type = number
 }
+
+variable "email_application_id" {
+  description = "The application ID used by chs-notification-api to render a template containing comparison results."
+  type = string
+  default = "data_reconciliation.data_reconciliation_email"
+}
+
+variable "email_message_id" {
+  description = "The message ID used by chs-notification-api to render a template containing comparison results."
+  type = string
+  default = "data_reconciliation_email_results"
+}
+
+variable "email_message_type" {
+  description = "The message type used by chs-notification-api to render a template containing comparison results."
+  type = string
+  default = "data_reconciliation_email_results"
+}


### PR DESCRIPTION
* Define S3 bucket for storing results generated from different
comparisons.
* Define properties for sending emails to desired recipients.