### PR TITLE
BI-7523 Add company status comparator crontab

### DIFF
--- a/groups/data-reconciliation/main.tf
+++ b/groups/data-reconciliation/main.tf
@@ -73,6 +73,7 @@ locals {
     company_collection_mongo_alpha_crontab = var.company_collection_mongo_alpha_crontab
     company_name_mongo_primary_crontab = var.company_name_mongo_primary_crontab
     company_name_mongo_alpha_crontab = var.company_name_mongo_alpha_crontab
+    company_status_mongo_primary_crontab = var.company_status_mongo_primary_crontab
     company_profile_db = var.company_profile_db
     company_profile_collection = var.company_profile_collection
     dsq_officer_db = var.dsq_officer_db

--- a/groups/data-reconciliation/profiles/development-eu-west-2/tbirds1/vars
+++ b/groups/data-reconciliation/profiles/development-eu-west-2/tbirds1/vars
@@ -6,13 +6,14 @@ state_prefix = "env:/development"
 aws_profile = "development-eu-west-2"
 ec2_key_pair_name = "chs-tbirds1"
 
-company_count_crontab = "0 5 6-17 * * MON-FRI"
+company_count_crontab = "0 0 6-17 * * MON-FRI"
 company_collection_crontab = "0 10 6-17 * * MON-FRI"
-dsq_officer_collection_crontab = "0 15 6-17 * * MON-FRI"
-company_collection_mongo_primary_crontab = "0 20 6-17 * * MON-FRI"
-company_collection_mongo_alpha_crontab = "0 25 6-17 * * MON-FRI"
-company_name_mongo_primary_crontab = "0 30 6-17 * * MON-FRI"
-company_name_mongo_alpha_crontab = "0 35 6-17 * * MON-FRI"
+dsq_officer_collection_crontab = "0 0 6-17 * * MON-FRI"
+company_collection_mongo_primary_crontab = "0 15 6-17 * * MON-FRI"
+company_collection_mongo_alpha_crontab = "0 15 6-17 * * MON-FRI"
+company_name_mongo_primary_crontab = "0 20 6-17 * * MON-FRI"
+company_name_mongo_alpha_crontab = "0 20 6-17 * * MON-FRI"
+company_status_mongo_primary_crontab = "0 20 6-17 * * MON-FRI"
 
 results_initial_capacity = 1000000
 results_expiry_time_in_millis = 1800000 # 30 minutes

--- a/groups/data-reconciliation/task-definition.tmpl
+++ b/groups/data-reconciliation/task-definition.tmpl
@@ -8,6 +8,7 @@
       { "name": "DSQ_OFFICER_COLLECTION_CRONTAB", "value": "${dsq_officer_collection_crontab}" },
       { "name": "COMPANY_NAME_MONGO_PRIMARY_CRONTAB", "value": "${company_name_mongo_primary_crontab}" },
       { "name": "COMPANY_NAME_MONGO_ALPHA_CRONTAB", "value": "${company_name_mongo_alpha_crontab}" },
+      { "name": "COMPANY_STATUS_MONGO_PRIMARY_CRONTAB", "value": "${company_status_mongo_primary_crontab}" },
       { "name": "SPRING_DATASOURCE_DRIVER_CLASS_NAME", "value": "${jdbc_driver}" },
       { "name": "ENDPOINT_MONGODB_COMPANY_PROFILE_DB_NAME", "value": "${company_profile_db}" },
       { "name": "ENDPOINT_MONGODB_COMPANY_PROFILE_COLLECTION_NAME", "value": "${company_profile_collection}" },

--- a/groups/data-reconciliation/variables.tf
+++ b/groups/data-reconciliation/variables.tf
@@ -111,6 +111,11 @@ variable "company_name_mongo_alpha_crontab" {
   type = string
 }
 
+variable "company_status_mongo_primary_crontab" {
+  description = "A crontab expression that will be used to trigger a comparison of company statuses between MongoDB and the Elasticsearch primary index."
+  type = string
+}
+
 variable "company_profile_db" {
   description = "The name of the MongoDB database used to store company profile documents."
   type = string


### PR DESCRIPTION
* New crontab for comparison between MongoDB and Elasticsearch primary
index (company statuses).
* Reorder comparison timings (for caching purposes).