### PR TITLE
Fix typos in cron expressions

### DIFF
--- a/groups/data-reconciliation/profiles/development-eu-west-2/tbirds1/vars
+++ b/groups/data-reconciliation/profiles/development-eu-west-2/tbirds1/vars
@@ -6,8 +6,8 @@ state_prefix = "env:/development"
 aws_profile = "development-eu-west-2"
 cpu_units = 1024
 memory = 8192
-startup_expression = "cron(0 0 6-17 * * MON-FRI)"
-shutdown_expression = "cron(0 30 6-17 * * MON-FRI)"
+startup_expression = "cron(0,0,6-17,*,*,MON-FRI)"
+shutdown_expression = "cron(0,30,6-17,*,*,MON-FRI)"
 
 company_count_delay = "0"
 company_number_mongo_oracle_delay = "30s"


### PR DESCRIPTION
* Cron expression expects args to be separated with commas.