### PR TITLE
Forcibly destroy S3 bucket

### DIFF
--- a/groups/data-reconciliation/main.tf
+++ b/groups/data-reconciliation/main.tf
@@ -57,6 +57,7 @@ module "secrets" {
 resource "aws_s3_bucket" "data-reconciliation-bucket" {
   bucket = local.name_prefix
   acl = "private"
+  force_destroy = true
 }
 
 module "data-reconcilliation-iam" {


### PR DESCRIPTION
* Set force_destroy to true on data-reconciliation S3 bucket; required
to prevent the destroy command from erroring due to a non-empty S3
bucket.