### PR TITLE
Pass credentials as secrets instead of env vars

### DIFF
--- a/groups/data-reconciliation/module-ecs/task-definition.tmpl
+++ b/groups/data-reconciliation/module-ecs/task-definition.tmpl
@@ -45,8 +45,6 @@
       { "name": "EMAIL_MESSAGE_ID", "value": "${email_message_id}" },
       { "name": "EMAIL_MESSAGE_TYPE", "value": "${email_message_type}" },
       { "name": "RESULTS_EXPIRY_TIME_IN_MILLIS", "value": "${results_expiry_time_in_millis}" },
-      { "name": "AWS_ACCESS_KEY_ID", "value": "${access_key_id}"},
-      { "name": "AWS_SECRET_ACCESS_KEY", "value": "${secret_access_key}"},
       { "name": "AWS_REGION", "value": "${aws_region}"},
       { "name": "CACHE_EXPIRY_IN_SECONDS", "value": "${cache_expiry_in_seconds}"},
       { "name": "JAVA_MEM_ARGS", "value": "${java_mem_args}"}
@@ -78,7 +76,9 @@
       { "name": "EMAIL_RECIPIENT_LIST", "valueFrom": "${data-reconciliation-secret-email-recipient-list}" },
       { "name": "EMAIL_SENDER", "valueFrom": "${data-reconciliation-secret-email-sender}" },
       { "name": "SCHEMA_REGISTRY_URL", "valueFrom": "${data-reconciliation-schema-registry-url}" },
-      { "name": "KAFKA_BROKER_ADDR", "valueFrom": "${data-reconciliation-secret-kafka-broker-addr}" }
+      { "name": "KAFKA_BROKER_ADDR", "valueFrom": "${data-reconciliation-secret-kafka-broker-addr}" },
+      { "name": "AWS_ACCESS_KEY_ID", "valueFrom": "${aws_access_key_id}"},
+      { "name": "AWS_SECRET_ACCESS_KEY", "valueFrom": "${aws_secret_access_key}"}
     ]
   }
 ]


### PR DESCRIPTION
Pass credentials to the container as secrets instead of env vars, so that they are not visible in the task definition.
Also adds bucket encryption setting to match that currently deployed.

Resolves:
https://companieshouse.atlassian.net/browse/DVOP-2755